### PR TITLE
backend: replace bson's json_util with standard json module

### DIFF
--- a/backend/liberouterapi/Auth.py
+++ b/backend/liberouterapi/Auth.py
@@ -1,3 +1,4 @@
+import json
 import bcrypt
 from functools import wraps
 from flask import request
@@ -43,7 +44,7 @@ class Auth(object):
             'code' : code,
             'description' : self.errors[str(code)]
         }
-        res = json_util.dumps(msg)
+        res = json.dumps(msg)
         return msg
 
     def login(self, user):

--- a/backend/liberouterapi/Response.py
+++ b/backend/liberouterapi/Response.py
@@ -1,10 +1,10 @@
+import json
 from flask import Response
-from bson import json_util
 
 class ResponseHandler(Response):
 	def __init__(self, content = None, *args, **kwargs):
 		if isinstance(content, (dict, list)):
-			content = json_util.dumps(content)
+			content = json.dumps(content)
 		super(Response, self).__init__(content, *args, **kwargs)
 
 	@classmethod

--- a/backend/liberouterapi/__init__.py
+++ b/backend/liberouterapi/__init__.py
@@ -40,7 +40,6 @@ from .role import Role
 
 # System tools
 import ssl
-from bson import json_util
 
 if config["api"].getboolean("ssl", False):
     context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)

--- a/backend/liberouterapi/bootstrap.py
+++ b/backend/liberouterapi/bootstrap.py
@@ -1,10 +1,10 @@
 from __future__ import print_function
 
 import sys
+import json
 import pkgutil
 from getpass import getpass
 from flask import request
-from bson import json_util
 import logging
 import os
 
@@ -136,6 +136,6 @@ def setup():
         res = unprotected_add_user(user)
 
         config.setup = False
-        return(json_util.dumps({ "user_id" : res}))
+        return(json.dumps({ "user_id" : res}))
     except Exception as e:
         raise ApiException({"error" : str(e)})

--- a/backend/liberouterapi/modules/authorization.py
+++ b/backend/liberouterapi/modules/authorization.py
@@ -1,5 +1,5 @@
+import json
 from flask import request
-from bson import json_util
 
 from liberouterapi import auth, db
 from liberouterapi.modules.module import Module
@@ -27,14 +27,15 @@ def login():
 
 	session_id = auth.store_session(user)
 
-	return(json_util.dumps({"session_id" : session_id, "user" : auth_user}))
+	return(json.dumps({"session_id" : session_id, "user" : auth_user}))
+
 
 @au.route('', methods=['DELETE'])
 @auth.required()
 def logout():
 	session_id = request.headers.get('Authorization', None)
 	auth.delete(session_id)
-	return(json_util.dumps({"success" : True}))
+	return(json.dumps({"success" : True}))
 
 
 """

--- a/backend/liberouterapi/modules/configuration.py
+++ b/backend/liberouterapi/modules/configuration.py
@@ -15,7 +15,7 @@ from liberouterapi.error import ApiException
 from liberouterapi.role import Role
 from liberouterapi.modules.module import Module
 #from liberouterapi.ConfigurationDatabase import ConfigurationDatabase as ConfDB
-from bson import json_util as json
+import json
 from pymongo import ReturnDocument
 
 class ConfError(ApiException):

--- a/backend/liberouterapi/modules/users.py
+++ b/backend/liberouterapi/modules/users.py
@@ -1,5 +1,5 @@
+import json
 from flask import request
-from bson import json_util
 import logging
 
 from liberouterapi import auth, db
@@ -28,13 +28,15 @@ def get_users():
     # Remove password hash from the resulting query
     for user in res:
         del user["password"]
-    return(json_util.dumps(res))
+    return(json.dumps(res))
+
 
 @auth.required()
 def get_user(user_id):
     user = db.get("users", "id", user_id)
     user.pop('password', None)
-    return(json_util.dumps(user))
+    return(json.dumps(user))
+
 
 def unprotected_add_user(user):
     """
@@ -67,7 +69,8 @@ def add_user():
     user.user_id = str(unprotected_add_user(user))
     user.password = None
 
-    return(json_util.dumps(user.to_dict()))
+    return(json.dumps(user.to_dict()))
+
 
 @auth.required(Role.admin)
 def remove_user(user_id):
@@ -89,7 +92,8 @@ def remove_user(user_id):
 
     user.password = None
 
-    return(json_util.dumps(user.to_dict()))
+    return(json.dumps(user.to_dict()))
+
 
 @auth.required()
 def edit_user(user_id):
@@ -139,7 +143,8 @@ def edit_user(user_id):
     # Remove password hash from the response
     del res['password']
 
-    return(json_util.dumps(res))
+    return(json.dumps(res))
+
 
 users.add_url_rule('', view_func=get_users, methods=['GET'])
 users.add_url_rule('', view_func=add_user, methods=['POST'])

--- a/backend/tests/users.py
+++ b/backend/tests/users.py
@@ -7,9 +7,9 @@ Test Case for users endpoints
 /users/:user_id [DELETE] - delete the user specified by user_id
 """
 
+import json
 from tests.api import SecureAPI
 from tests.req import ApiAuth
-from bson import json_util
 
 class UsersTestCase(SecureAPI):
     def test_users_0_get_users(self):
@@ -106,7 +106,7 @@ class UsersTestCase(SecureAPI):
                 "first_name" : "John"
                 }
 
-        r = self.req.PUT('/users/' + user_id, auth = ApiAuth(self.user['session_id']), data = json_util.dumps(data))
+        r = self.req.PUT('/users/' + user_id, auth = ApiAuth(self.user['session_id']), data = json.dump(data))
 
         self.assertOK(r)
         new_user = r.json()
@@ -196,7 +196,7 @@ class UsersTestCase(SecureAPI):
                 "first_name" : "John"
                 }
 
-        r = self.req.PUT('/users/' + guest_id, auth = ApiAuth(user_role.json()['session_id']), data = json_util.dumps(data))
+        r = self.req.PUT('/users/' + guest_id, auth = ApiAuth(user_role.json()['session_id']), data = json.dumps(data))
 
         self.assertTrue(r.status_code == 401)
 


### PR DESCRIPTION
Data handled by liberouterapi does not use bson extension so it is
not necessary to use the bson's wrapper around standard json module.